### PR TITLE
Update default theme in docs

### DIFF
--- a/grav/readme.md
+++ b/grav/readme.md
@@ -12,8 +12,8 @@ docker run \
   -v $(pwd)/user:/var/www/html/user \
   -p 3030:80 \
   --name mygrav -d benjick/grav
-# Installs the default theme 'antimatter'
-docker exec mygrav bin/gpm install antimatter
+# Installs the default theme 'Quark'
+docker exec mygrav bin/gpm install quark
 ```
 
 Now you can go to localhost:3030 and see your page in action.


### PR DESCRIPTION
As stated in Grav docs:
"theme: This is where you set the default theme. This defaults to quark."

And when you install Quark and go to typography:
"The Quark theme is the new default theme for Grav built with Spectre.css the lightweight, responsive and modern CSS framework. Spectre provides basic styles for typography, elements, and a responsive layout system that utilizes best practices and consistent language design."